### PR TITLE
Whitelist support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Arguments:
 - `--remove-uri-prefix` is prefix to be removed
 - `--with-request-transformer` Run publisher with request transformer. If you have dynamic path as path parameter that need to call, You must use this argument (currently only support numerical value of path parameter).
 - `--with-oidc` Run publisher with OIDC. value is `;` separator of OIDC client id, client secret, discovery, introspection endpoint and the token auth method.
-- `--with-jwt` Run publisher with JWT.
+- `--with-jwt` Run publisher with JWT. value is the onelogin consumer id (for corresponding env)
 
 Env used:
 - `KONG_ADMIN_HOST` value is your kong admin host. for example:
@@ -34,7 +34,7 @@ convention in contacts is:
 
 later when publishing route you can call
 ```
-$ php artisan kong:publish-route contacts --upstream-host=http://mockbin.com/request --remove-uri-prefix=api/v1  --with-request-transformer --with-jwt --with-oidc=someclientid;someclientsecret;https://onelogin.com/.well-known/discovery;https://onelogin.com/token/introspection;client_secret_basic
+$ php artisan kong:publish-route contacts --upstream-host=http://mockbin.com/request --remove-uri-prefix=api/v1  --with-request-transformer --with-jwt=xxxx --with-oidc=someclientid;someclientsecret;https://onelogin.com/.well-known/discovery;https://onelogin.com/token/introspection;client_secret_basic
 ```
 
 it will make route in apigateway become:

--- a/src/AuthPlugin.php
+++ b/src/AuthPlugin.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace KWRI\Kong\RoutePublisher;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+abstract class AuthPlugin
+{
+    public function createActivatePluginPayload(Collection $payload)
+    {
+        if ($payload->has('middlewares') && in_array('auth', $payload->get('middlewares'))) {
+            // Only enabled auth plugin for those that really need them
+            $this->setPluginPayload($payload);
+        } else {
+            return [];
+        }
+    }
+
+    abstract protected function setPluginPayload(Collection $payload);
+}

--- a/src/Console/RouteRefreshCommand.php
+++ b/src/Console/RouteRefreshCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace KWRI\Kong\RoutePublisher\Console;
+
+use Illuminate\Console\Command;
+
+class RouteRefreshCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'kong:refresh-route {appName}';
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Republish all registered routes to Kong (if all setup requirements found in .env).';
+
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        $app = $this->laravel;
+        $appName = $this->argument('appName');
+        if (env('KONG_PUBLISHER_JWT')
+            && env('KONG_PUBLISHER_OIDC')
+            && env('KONG_PUBLISHER_UPSTREAM_HOST')
+            && env('KONG_PUBLISHER_REMOVED_URI_PREFIX')) {
+
+            $this->call('kong:delete-route', [
+                'appName' => $appName,
+                '--force' => true
+            ]);
+            $this->call('kong:publish-route', [
+                'appName' => $appName,
+                '--upstream-host' => env('KONG_PUBLISHER_UPSTREAM_HOST'),
+                '--remove-uri-prefix' => env('KONG_PUBLISHER_REMOVED_URI_PREFIX'),
+                '--with-request-transformer' => true,
+                '--with-jwt' => env('KONG_PUBLISHER_JWT'),
+                '--with-oidc' => env('KONG_PUBLISHER_OIDC'),
+                '--force' => true
+            ]);
+        }
+    }
+}

--- a/src/Jwt.php
+++ b/src/Jwt.php
@@ -4,9 +4,20 @@ namespace KWRI\Kong\RoutePublisher;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
-class Jwt implements BehaviorInterface
+class Jwt extends AuthPlugin implements BehaviorInterface
 {
     const PLUGIN_NAME = 'jwt';
+
+    /**
+     * @var string
+     */
+    private $anonymousId = 'undefined';
+
+
+    public function __construct($anonymousId)
+    {
+        $this->anonymousId = $anonymousId;
+    }
 
     public function transformPayload(Collection $payload)
     {
@@ -18,10 +29,11 @@ class Jwt implements BehaviorInterface
         $client->updateOrAddPlugin($payload->offsetGet('name'), $this->createActivatePluginPayload($payload));
     }
 
-    public function createActivatePluginPayload(Collection $payload)
+    protected function setPluginPayload(Collection $payload)
     {
         $pluginPayload = [
             'name' => self::PLUGIN_NAME,
+            'config.anonymous' => $this->anonymousId,
         ];
 
         return $pluginPayload;

--- a/src/KongClient.php
+++ b/src/KongClient.php
@@ -24,6 +24,8 @@ class KongClient
                 $this->delete($payload);
             } catch (\Exception $e) {}
 
+            $payload = $this->filterPayload($payload);
+
             return $this->client->put('/apis/', [
                 'json' => $payload
             ]);
@@ -31,6 +33,11 @@ class KongClient
 
         public function updateOrAddPlugin($name, array $payload)
         {
+            // Nothing need to happen
+            if (empty($payload)) return;
+
+            $payload = $this->filterPayload($payload);
+
             return $this->client->put("/apis/{$name}/plugins/", [
                 'json' => $payload
             ]);
@@ -46,5 +53,15 @@ class KongClient
             return $this->client->get('/apis/', [
                 'query' => $payload
             ]);
+        }
+
+        protected function filterPayload(array $payload)
+        {
+            // Filter out middlewares
+            if (isset($payload['middlewares'])) {
+                unset($payload['middlewares']);
+            }
+
+            return $payload;
         }
 }

--- a/src/KongPublisherServiceProvider.php
+++ b/src/KongPublisherServiceProvider.php
@@ -3,6 +3,7 @@ namespace KWRI\Kong\RoutePublisher;
 
 use Illuminate\Support\ServiceProvider;
 use GuzzleHttp\Client as GuzzleClient;
+use KWRI\Kong\RoutePublisher\Console\RouteRefreshCommand;
 use KWRI\Kong\RoutePublisher\Console\RoutePublishCommand;
 use KWRI\Kong\RoutePublisher\Console\RouteDeleteCommand;
 
@@ -16,10 +17,12 @@ class KongPublisherServiceProvider extends ServiceProvider
             return new KongClient($client);
         });
 
+        $this->app->singleton('kong.route-refresh', RouteRefreshCommand::class);
         $this->app->singleton('kong.route-publisher', RoutePublishCommand::class);
         $this->app->singleton('kong.route-destroyer', RouteDeleteCommand::class);
 
         $this->commands(
+          'kong.route-refresh',
           'kong.route-publisher',
           'kong.route-destroyer'
         );

--- a/src/Oidc.php
+++ b/src/Oidc.php
@@ -4,7 +4,7 @@ namespace KWRI\Kong\RoutePublisher;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
-class Oidc implements BehaviorInterface
+class Oidc extends AuthPlugin implements BehaviorInterface
 {
     const PLUGIN_NAME = 'oidc';
 
@@ -52,7 +52,7 @@ class Oidc implements BehaviorInterface
         $client->updateOrAddPlugin($payload->offsetGet('name'), $this->createActivatePluginPayload($payload));
     }
 
-    public function createActivatePluginPayload(Collection $payload)
+    protected function setPluginPayload(Collection $payload)
     {
         $pluginPayload = [
             'name' => self::PLUGIN_NAME,


### PR DESCRIPTION
- The plugin now will whitelist all non `auth` routes for any auth plugin (currently oidc and jwt)
- Added `route-refresh` command for convenience usage (if its detect `KONG_PUBLISHER_*` in the app `.env`)